### PR TITLE
Minor cleanup

### DIFF
--- a/src/Game/Entities/Game.cpp
+++ b/src/Game/Entities/Game.cpp
@@ -312,7 +312,7 @@ void Game::update()
 	// what currently is.
 	// It allows you to set a high current level even
 	// without clearing enough lines to get there.
-	unsigned int new_level = this->getLevel(Globals::Profiles::current->scores->score.lines);
+	int new_level = this->getLevel(Globals::Profiles::current->scores->score.lines);
 
 	if (new_level > Globals::Profiles::current->scores->score.level)
 		Globals::Profiles::current->scores->score.level = new_level;


### PR DESCRIPTION
Fix the compile warning: comparison between signed and unsigned integer expressions.

src/Game/Entities/Game.cpp: In member function ‘void Game::update()’:
src/Game/Entities/Game.cpp:317: warning: comparison between signed and unsigned integer expressions

Signed-off-by: hwangcc hwangcc@csie.nctu.edu.tw
