### PR TITLE
Add a "Game Over" menu

### DIFF
--- a/src/Game/Entities/Game.cpp
+++ b/src/Game/Entities/Game.cpp
@@ -312,7 +312,7 @@ void Game::update()
 	// what currently is.
 	// It allows you to set a high current level even
 	// without clearing enough lines to get there.
-	unsigned int new_level = this->getLevel(Globals::Profiles::current->scores->score.lines);
+	int new_level = this->getLevel(Globals::Profiles::current->scores->score.lines);
 
 	if (new_level > Globals::Profiles::current->scores->score.level)
 		Globals::Profiles::current->scores->score.level = new_level;

--- a/src/Game/Entities/Game.cpp
+++ b/src/Game/Entities/Game.cpp
@@ -319,7 +319,23 @@ void Game::update()
 
 	// Checking if game over
 	if (this->board->isFull())
+	{
+		// HACK change the pause menu to a game over menu
+		MenuItem* item;
+		this->layout->pause->setTitle("Game Over");
+		this->pauseMenu->removeByID(RESUME);
+		item = new MenuItem("Restart", RESUME);
+		this->pauseMenu->add(item);
+		this->pauseMenu->removeByID(QUIT_MENU);
+		item = new MenuItem("Quit to Main Menu", QUIT_MENU);
+		this->pauseMenu->add(item);
+		this->pauseMenu->removeByID(QUIT_GAME);
+		item = new MenuItem("Quit Game", QUIT_GAME);
+		this->pauseMenu->add(item);
+
 		this->gameOver = true;
+		this->pause(true);
+	}
 
 	// If on invisible mode, will flash the pieces
 	// once in a while
@@ -357,7 +373,7 @@ void Game::draw()
 }
 bool Game::isOver()
 {
-	return (this->gameOver);
+	return (this->gameOver && !this->isPaused);
 }
 bool Game::movePieceIfPossible(Piece::PieceDirection direction)
 {


### PR DESCRIPTION
Hi @alexdantas,

When the game is over, Yetris as-is restarts immediately.
Users don't have a chance to take a break or choose his next action.
This pull request adds a "Game Over" menu.
Please help to review and merge it.
Thanks.

![yetris_screenshot](https://cloud.githubusercontent.com/assets/1612266/6577816/73c93078-c77b-11e4-9ce6-01a4f6aecf55.png)
