### PR TITLE
PREFIX defaults to /usr but can be overridden via sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ VERSION = 2.3.0
 DATE    = $(shell date "+%b%Y")
 
 # Install dirs
-PREFIX      = /usr
+PREFIX      ?= /usr
 EXEC_PREFIX = $(PREFIX)
 DATAROOTDIR = $(PREFIX)/share
 BINDIR      = $(EXEC_PREFIX)/bin


### PR DESCRIPTION
Allows the user to set the PREFIX without modifying the Makefile.

Default:
```shell
$ make -n install
[... omit ...]
install -pdm755 /usr/share/man/man6
install -pm644 yetris.6 /usr/share/man/man6
rm -f yetris.6
# yetris successfuly installed!
$
```

Custom:
```shell
$ PREFIX=$HOME/.local make -n install
[... omit ...]
install -pdm755 /home/NAME/.local/share/man/man6
install -pm644 yetris.6 /home/NAME/.local/share/man/man6
rm -f yetris.6
# yetris successfuly installed!
$
```

Without the little `?` a user would have manually edit the Makefile or use sed.

NOTE:
Packages that use the GNU autoconf + automake tools give the user the option of overriding every possible install path.
This seems like overkill as the vast majority of cases I've seen are just particular about the PREFIX.
If this level of customization is desired then changing all of the `=` to `?=` should do the trick.

